### PR TITLE
Swap page fixes

### DIFF
--- a/src/pages/swap/main.jsx
+++ b/src/pages/swap/main.jsx
@@ -10,7 +10,7 @@ const SwapPage = () => {
           <div className={styles.frame_container}>
               <Text size={2} margin='0 0 2em 0' weight={1000}>Token Address:</Text>
               <Text size={2} margin='-1em 0 2em 0' weight={1000}>0x8c4885867d30f03ad04388cee01c65d11d192e61</Text>
-              <iframe src="https://poocoin.app/embed-swap" width="420" height="630"/> 
+              <iframe src="https://poocoin.app/embed-swap?outputCurrency=0x8c4885867D30F03AD04388cee01C65D11D192e61" width="420" height="630"/> 
           </div>
         </div>
       <Footer/>

--- a/src/pages/swap/styles.module.scss
+++ b/src/pages/swap/styles.module.scss
@@ -10,7 +10,7 @@
   align-items: center;
   width: 100vw;
   height: 100vh;
-  margin-top: 3em;
+  margin-top: 6em;
 }
 
 .frame_container {


### PR DESCRIPTION
This is all live on the site already. Preselecting MHTC in the poocoin embed, allowing scrolling in small screen landscape mode and preventing menu bar overlap with content.